### PR TITLE
Make tests less flaky and be able to run under Swift 2.2/Xcode 7.3.

### DIFF
--- a/BoltsSwift.xcodeproj/project.pbxproj
+++ b/BoltsSwift.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		065895131C9A947B000FDDA6 /* TaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D300781C93AF9F00E1A1ED /* TaskTests.swift */; };
 		065895141C9A947B000FDDA6 /* TaskCompletionSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D300771C93AF9F00E1A1ED /* TaskCompletionSourceTests.swift */; };
 		0658951F1C9A9496000FDDA6 /* BoltsSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 065894FF1C9A93B7000FDDA6 /* BoltsSwift.framework */; };
+		810AB3201C9B1AC3005B6184 /* XCTestCase+TestName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810AB31F1C9B1AC3005B6184 /* XCTestCase+TestName.swift */; };
+		810AB3211C9B1AC3005B6184 /* XCTestCase+TestName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810AB31F1C9B1AC3005B6184 /* XCTestCase+TestName.swift */; };
+		810AB3221C9B1AC3005B6184 /* XCTestCase+TestName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810AB31F1C9B1AC3005B6184 /* XCTestCase+TestName.swift */; };
 		81CC14F71A9BE0A100B28F86 /* BoltsSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81CC14EC1A9BE0A100B28F86 /* BoltsSwift.framework */; };
 		81D300681C93AF7300E1A1ED /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D300631C93AF7300E1A1ED /* Errors.swift */; };
 		81D300691C93AF7300E1A1ED /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D300631C93AF7300E1A1ED /* Errors.swift */; };
@@ -65,6 +68,7 @@
 		065894E71C9A933B000FDDA6 /* BoltsSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BoltsSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		065894FF1C9A93B7000FDDA6 /* BoltsSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BoltsSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0658951B1C9A947B000FDDA6 /* BoltsSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoltsSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		810AB31F1C9B1AC3005B6184 /* XCTestCase+TestName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+TestName.swift"; sourceTree = "<group>"; };
 		81CC14EC1A9BE0A100B28F86 /* BoltsSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BoltsSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81CC14F61A9BE0A100B28F86 /* BoltsSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoltsSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		81D300631C93AF7300E1A1ED /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -170,6 +174,7 @@
 				81D300781C93AF9F00E1A1ED /* TaskTests.swift */,
 				81D300771C93AF9F00E1A1ED /* TaskCompletionSourceTests.swift */,
 				81D300751C93AF9F00E1A1ED /* ExecutorTests.swift */,
+				810AB31F1C9B1AC3005B6184 /* XCTestCase+TestName.swift */,
 				81D300811C93AFA600E1A1ED /* Supporting Files */,
 			);
 			path = Tests;
@@ -501,6 +506,7 @@
 				065895121C9A947B000FDDA6 /* ExecutorTests.swift in Sources */,
 				065895131C9A947B000FDDA6 /* TaskTests.swift in Sources */,
 				065895141C9A947B000FDDA6 /* TaskCompletionSourceTests.swift in Sources */,
+				810AB3221C9B1AC3005B6184 /* XCTestCase+TestName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -522,6 +528,7 @@
 				81D3007A1C93AF9F00E1A1ED /* ExecutorTests.swift in Sources */,
 				81D300801C93AF9F00E1A1ED /* TaskTests.swift in Sources */,
 				81D3007E1C93AF9F00E1A1ED /* TaskCompletionSourceTests.swift in Sources */,
+				810AB3211C9B1AC3005B6184 /* XCTestCase+TestName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -543,6 +550,7 @@
 				81D300791C93AF9F00E1A1ED /* ExecutorTests.swift in Sources */,
 				81D3007F1C93AF9F00E1A1ED /* TaskTests.swift in Sources */,
 				81D3007D1C93AF9F00E1A1ED /* TaskCompletionSourceTests.swift in Sources */,
+				810AB3201C9B1AC3005B6184 /* XCTestCase+TestName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -939,6 +947,7 @@
 				065894ED1C9A933B000FDDA6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		065894FC1C9A93B7000FDDA6 /* Build configuration list for PBXNativeTarget "BoltsSwift-tvOS" */ = {
 			isa = XCConfigurationList;

--- a/Tests/ExecutorTests.swift
+++ b/Tests/ExecutorTests.swift
@@ -53,15 +53,19 @@ class ExecutorTests: XCTestCase {
 
     func testQueueExecute() {
         let expectation = expectationWithDescription(currentTestName)
+                let semaphore = dispatch_semaphore_create(0)
         var finished = false
 
         Executor.Queue(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)).execute {
-            expectation.fulfill()
+            dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
             finished = true
+            expectation.fulfill()
         }
 
         XCTAssertFalse(finished)
+        dispatch_semaphore_signal(semaphore)
         waitForExpectationsWithTimeout(0.5, handler: nil)
+        XCTAssertTrue(finished)
     }
 
     func testClosureExecute() {
@@ -78,16 +82,20 @@ class ExecutorTests: XCTestCase {
 
     func testOperationQueueExecute() {
         let expectation = expectationWithDescription(currentTestName)
-        let operationQueue = NSOperationQueue()
+        let semaphore = dispatch_semaphore_create(0)
         var finished = false
 
+        let operationQueue = NSOperationQueue()
         Executor.OperationQueue(operationQueue).execute {
-            expectation.fulfill()
+            dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
             finished = true
+            expectation.fulfill()
         }
 
         XCTAssertFalse(finished)
+        dispatch_semaphore_signal(semaphore)
         waitForExpectationsWithTimeout(0.5, handler: nil)
+        XCTAssertTrue(finished)
     }
 
     // MARK: Descriptions

--- a/Tests/ExecutorTests.swift
+++ b/Tests/ExecutorTests.swift
@@ -13,7 +13,7 @@ import BoltsSwift
 class ExecutorTests: XCTestCase {
 
     func testDefaultExecute() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
 
         var finished = false
         Executor.Default.execute {
@@ -26,7 +26,7 @@ class ExecutorTests: XCTestCase {
     }
 
     func testImmediateExecute() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
 
         var finished = false
         Executor.Immediate.execute {
@@ -39,7 +39,7 @@ class ExecutorTests: XCTestCase {
     }
 
     func testMainExecute() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
 
         var finished = false
         Executor.MainThread.execute {
@@ -52,7 +52,7 @@ class ExecutorTests: XCTestCase {
     }
 
     func testQueueExecute() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         var finished = false
 
         Executor.Queue(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)).execute {
@@ -65,7 +65,7 @@ class ExecutorTests: XCTestCase {
     }
 
     func testClosureExecute() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
 
         Executor.Closure { closure in
             closure()
@@ -77,7 +77,7 @@ class ExecutorTests: XCTestCase {
     }
 
     func testOperationQueueExecute() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let operationQueue = NSOperationQueue()
         var finished = false
 

--- a/Tests/TaskCompletionSourceTests.swift
+++ b/Tests/TaskCompletionSourceTests.swift
@@ -27,7 +27,7 @@ class TaskCompletionSourceTests: XCTestCase {
         let sut = TaskCompletionSource<String>()
         let task = sut.task
 
-        sut.setResult(name)
+        sut.setResult(currentTestName)
 
         XCTAssertTrue(task.completed)
         XCTAssertNotNil(task.result)
@@ -61,7 +61,7 @@ class TaskCompletionSourceTests: XCTestCase {
         let sut = TaskCompletionSource<String>()
         let task = sut.task
 
-        let success = sut.trySetResult(name)
+        let success = sut.trySetResult(currentTestName)
 
         XCTAssertTrue(success)
         XCTAssertTrue(task.completed)
@@ -96,9 +96,9 @@ class TaskCompletionSourceTests: XCTestCase {
 
     func testTrySetResultReturningFalse() {
         let sut = TaskCompletionSource<String>()
-        sut.setResult(name)
+        sut.setResult(currentTestName)
 
-        let success = sut.trySetResult(name)
+        let success = sut.trySetResult(currentTestName)
 
         XCTAssertFalse(success)
     }
@@ -106,7 +106,7 @@ class TaskCompletionSourceTests: XCTestCase {
     func testTrySetErrorReturningFalse() {
         let error = NSError(domain: "com.bolts", code: 1, userInfo: nil)
         let sut = TaskCompletionSource<String>()
-        sut.setResult(name)
+        sut.setResult(currentTestName)
 
         let success = sut.trySetError(error)
 
@@ -115,7 +115,7 @@ class TaskCompletionSourceTests: XCTestCase {
 
     func testTryCancelReturningFalse() {
         let sut = TaskCompletionSource<String>()
-        sut.setResult(name)
+        sut.setResult(currentTestName)
         let success = sut.tryCancel()
         XCTAssertFalse(success)
     }

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -15,10 +15,10 @@ class TaskTests: XCTestCase {
     // MARK: Initializers
 
     func testWithResult() {
-        let task = Task(name)
+        let task = Task(currentTestName)
 
         XCTAssertNotNil(task.result)
-        XCTAssertEqual(task.result, name)
+        XCTAssertEqual(task.result, currentTestName)
         XCTAssertTrue(task.completed)
         XCTAssertFalse(task.faulted)
         XCTAssertFalse(task.cancelled)
@@ -50,7 +50,7 @@ class TaskTests: XCTestCase {
     // MARK: Task with Delay
 
     func testWithDelay() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task<String>.withDelay(0.01)
         task.continueWith { task in
             expectation.fulfill()
@@ -63,7 +63,7 @@ class TaskTests: XCTestCase {
     // MARK: Execute
 
     func testExecuteWithClosureReturningNil() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task<String> {
             expectation.fulfill()
             return "Hello, World!"
@@ -73,10 +73,10 @@ class TaskTests: XCTestCase {
     }
 
     func testExecuteWithClosureReturningValue() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task<String> {
             expectation.fulfill()
-            return self.name
+            return self.currentTestName
         }
         waitForExpectationsWithTimeout(0.5, handler: nil)
         XCTAssertNotNil(task.result)
@@ -84,7 +84,7 @@ class TaskTests: XCTestCase {
     }
 
     func testExecuteWithClosureReturningTaskWithResult() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task.executeWithTask { () -> Task<Int> in
             expectation.fulfill()
             return Task(10)
@@ -95,7 +95,7 @@ class TaskTests: XCTestCase {
     }
 
     func testExecuteWithClosureReturningCancelledTask() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task<Void>.executeWithTask { () -> Task<Void> in
             expectation.fulfill()
             return Task<Void>.cancelledTask()
@@ -196,7 +196,7 @@ class TaskTests: XCTestCase {
     func testContinueWithByReturningTask() {
         let expectation = expectationWithDescription("continuationTaskSucceeds")
         let firstTask = Task(1)
-        let secondTask = Task(name)
+        let secondTask = Task(currentTestName)
 
         let continuationTask = firstTask.continueWithTask { task -> Task<String> in
             XCTAssertTrue(task === firstTask)
@@ -226,7 +226,7 @@ class TaskTests: XCTestCase {
     }
 
     func testChainedContinueWithFunctions() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         var count = 0
 
         Task<Void>.cancelledTask().continueWith { _ -> String? in
@@ -256,7 +256,7 @@ class TaskTests: XCTestCase {
     }
 
     func testChainedContinueWithWithAsyncExecutor() {
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let executor = Executor.Queue(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0))
         var count = 0
 
@@ -296,7 +296,7 @@ class TaskTests: XCTestCase {
             tasks.append(task)
         }
 
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task.whenAll(tasks).continueWith { task in
             XCTAssertEqual(count, Int32(tasks.count))
             XCTAssertTrue(task.completed)
@@ -326,7 +326,7 @@ class TaskTests: XCTestCase {
             tasks.append(task)
         }
 
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task.whenAllResult(tasks).continueWith { task in
             XCTAssertEqual(count, Int32(tasks.count))
             XCTAssertTrue(task.completed)
@@ -360,7 +360,7 @@ class TaskTests: XCTestCase {
             tasks.append(task)
         }
 
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task.whenAllResult(tasks).continueWith { task in
             XCTAssertEqual(count, Int32(tasks.count))
             XCTAssertTrue(task.completed)
@@ -393,7 +393,7 @@ class TaskTests: XCTestCase {
             tasks.append(task)
         }
 
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task.whenAny(tasks).continueWith { task in
             XCTAssertNotEqual(count, Int32(tasks.count))
             XCTAssertTrue(task.completed)
@@ -425,7 +425,7 @@ class TaskTests: XCTestCase {
             tasks.append(task)
         }
 
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task.whenAny(tasks).continueWith { task in
             XCTAssertNotEqual(count, Int32(tasks.count))
             XCTAssertTrue(task.completed)
@@ -456,7 +456,7 @@ class TaskTests: XCTestCase {
             tasks.append(task)
         }
 
-        let expectation = expectationWithDescription(name)
+        let expectation = expectationWithDescription(currentTestName)
         let task = Task.whenAny(tasks).continueWith { task in
             XCTAssertNotEqual(count, Int32(tasks.count))
             XCTAssertTrue(task.completed)

--- a/Tests/XCTestCase+TestName.swift
+++ b/Tests/XCTestCase+TestName.swift
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2016, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import XCTest
+
+extension XCTestCase {
+
+    /**
+     Returns current test name or `test` if it's nil.
+     Since Swift 2.2 and 2.1 have different XCTest API - we need to wrap this here.
+     */
+    var currentTestName: String {
+        return name ?? "test"
+    }
+}


### PR DESCRIPTION
- We have some flaky tests, because operations can run faster than we execute on the current thread
- Also, since XCTest APIs is different between 2.2 and 2.1 - we need to wrap `name`
