### PR TITLE
README: Fix syntax in example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ After you create a `TaskCompletionSource`, you need to call `setResult()`/`setEr
 ```swift
 func fetch(object: PFObject) -> Task<PFObject> {
   let taskCompletionSource = TaskCompletionSource<PFObject>()
-  object.fetchInBackgroundWithBlock() { object?, error? 
+  object.fetchInBackgroundWithBlock() { (object: PFObject?, error: NSError?) in
     if let error = error {
       taskCompletionSource.setError(error)
     } else if let object = object {


### PR DESCRIPTION
If I am not mistaken, the example code uses a non-existing syntax for the arguments of the closure. This merge request uses the correct syntax so the example code is more understandable.
