### PR TITLE
Fix usage of CancelledError, add tests for error handling inside tasks.

### DIFF
--- a/Sources/BoltsSwift/Errors.swift
+++ b/Sources/BoltsSwift/Errors.swift
@@ -26,4 +26,9 @@ public struct AggregateError: ErrorType {
 
  Return or throw this from a continuation closure to propagate to the `task.cancelled` property.
  */
-public struct CancelledError: ErrorType { }
+public struct CancelledError: ErrorType {
+    /**
+     Initializes a Cancelled Error.
+     */
+    public init() { }
+}

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -104,6 +104,31 @@ class TaskTests: XCTestCase {
         XCTAssertTrue(task.cancelled)
     }
 
+    func textExecuteWithClosureThrowingError() {
+        let expectation = expectationWithDescription(currentTestName)
+        let task = Task<String>.execute {
+            defer {
+                expectation.fulfill()
+            }
+            throw NSError(domain: "com.bolts", code: 1, userInfo: nil)
+        }
+        waitForTestExpectations()
+        XCTAssertNotNil(task.error)
+    }
+
+    func testExecuteWithClosureThrowingCancelledError() {
+        let expectation = expectationWithDescription(currentTestName)
+        let task = Task<String>.execute {
+            defer {
+                expectation.fulfill()
+            }
+            throw CancelledError()
+        }
+        waitForTestExpectations()
+        XCTAssertTrue(task.cancelled)
+        XCTAssertNil(task.error)
+    }
+
     // MARK: Continuations
 
     func testContinueWithOnSucessfulTaskByReturningResult() {


### PR DESCRIPTION
Looks like we were missing a constructor, which was making CancelledError pretty much useless OOB.
