### PR TITLE
Resolve retain cycle in Task

### DIFF
--- a/Sources/BoltsSwift/Task.swift
+++ b/Sources/BoltsSwift/Task.swift
@@ -385,6 +385,7 @@ public final class Task<TResult> {
                 stateChanged = true
                 self._state = state
                 continuations = self._continuations
+                self._continuations.removeAll()
             default:
                 break
             }


### PR DESCRIPTION
When I implemented following code in UIViewController, it was not released.

``` Swift
let tcs = TaskCompletionSource<String>()
tcs.task.continueWith { task -> () in
    let alert = UIAlertController(title: nil, message: task.result!, preferredStyle: .Alert)
    alert.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: nil))
    self.presentViewController(alert, animated: true, completion: nil)
}
tcs.setResult("debug")
```

I think there is a retain cycle in here: 
https://github.com/BoltsFramework/Bolts-Swift/blob/master/Sources/BoltsSwift/Task.swift#L161

``` Swift
public func continueWithTask<S>(executor: Executor = .Default, continuation: (Task throws -> Task<S>)) -> Task<S> {
    let taskCompletionSource = TaskCompletionSource<S>()
    let wrapperContinuation = {
        executor.execute {
            let wrappedState = TaskState<Task<S>>.fromClosure {
                try continuation(self)
            }
            switch wrappedState {
            case .Success(let nextTask):
                switch nextTask.state {
                case .Pending:
                    nextTask.continueWith { nextTask in
                        taskCompletionSource.setState(nextTask.state)
                    }
                default:
                    taskCompletionSource.setState(nextTask.state)
                }
            case .Error(let error):
                taskCompletionSource.setError(error)
            case .Cancelled:
                taskCompletionSource.cancel()
            default: abort() // This should never happen.
            }
        }
    }
    appendOrRunContinuation(wrapperContinuation)
    return taskCompletionSource.task
}
```

`wrapperContinuation` will be stored in `_continuations` when the Task state is `Pending`.
And `wrapperContinuation` has strong reference to self.

So I remove all from `_continuations` when It consumed.
