### PR TITLE
Refactor continuation to be better, faster, stronger.

### DIFF
--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -565,8 +565,8 @@ class TaskTests: XCTestCase {
         let executor = Executor.Queue(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0))
         let error = NSError(domain: "com.bolts", code: 1, userInfo: nil)
 
-        for _ in 1...20 {
-            let task = Task<Void>.withDelay(0.5)
+        for i in 1...20 {
+            let task = Task<Void>.withDelay(Double(i) * 0.5)
                 .continueWithTask(executor, continuation: { task -> Task<Void> in
                     OSAtomicIncrement32(&count)
                     return Task(error: error)


### PR DESCRIPTION
Currently, it's a bit odd that continuing on a task conditionally (e.g. continueOnSuccessWith, continueOnErrorWith) **always** runs on that executor, even if we know the continuation won't run.

It seems like it could hurt performance (especially when it comes to using the MainThread executor).

This PR changes the way we store continuations, to be a combination of closure and an enum representing the cases in which it executes under (always, success, error, cancelled, etc.)

This way, we don't have to dispatch onto the executor unless we _know_ that the continuation will be successful, and we can extract our logic that we currently use in continueOnSuccessWith into a more unified place.
