### PR TITLE
Make all 'trySet', 'set' functions to use explicit argument labels.

### DIFF
--- a/Sources/BoltsSwift/Task+ContinueWith.swift
+++ b/Sources/BoltsSwift/Task+ContinueWith.swift
@@ -45,7 +45,7 @@ extension Task {
                             taskCompletionSource.setState(nextTask.state)
                         }
                     case .Error(let error):
-                        taskCompletionSource.setError(error)
+                        taskCompletionSource.set(error: error)
                     case .Cancelled:
                         taskCompletionSource.cancel()
                     default: abort() // This should never happen.
@@ -54,10 +54,10 @@ extension Task {
 
             case .Success(let result as S):
                 // This is for continueOnErrorWith - the type of the result doesn't change, so we can pass it through
-                taskCompletionSource.setResult(result)
+                taskCompletionSource.set(result: result)
 
             case .Error(let error):
-                taskCompletionSource.setError(error)
+                taskCompletionSource.set(error: error)
 
             case .Cancelled:
                 taskCompletionSource.cancel()

--- a/Sources/BoltsSwift/Task+Delay.swift
+++ b/Sources/BoltsSwift/Task+Delay.swift
@@ -25,7 +25,7 @@ extension Task {
         let taskCompletionSource = TaskCompletionSource<Void>()
         let time = dispatch_time(DISPATCH_TIME_NOW, Int64(delay * NSTimeInterval(NSEC_PER_SEC)))
         dispatch_after(time, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            taskCompletionSource.trySetResult()
+            taskCompletionSource.trySet(result: ())
         }
         return taskCompletionSource.task
     }

--- a/Sources/BoltsSwift/Task+WhenAll.swift
+++ b/Sources/BoltsSwift/Task+WhenAll.swift
@@ -44,9 +44,9 @@ extension Task {
                     if cancelledCount > 0 {
                         tcs.cancel()
                     } else if errorCount > 0 {
-                        tcs.setError(AggregateError(errors: tasks.flatMap({ $0.error })))
+                        tcs.set(error: AggregateError(errors: tasks.flatMap({ $0.error })))
                     } else {
-                        tcs.setResult()
+                        tcs.set(result: ())
                     }
                 }
             }

--- a/Sources/BoltsSwift/Task+WhenAny.swift
+++ b/Sources/BoltsSwift/Task+WhenAny.swift
@@ -36,7 +36,7 @@ extension Task {
                 break
             }
             task.continueWith { task in
-                taskCompletionSource.trySetResult()
+                taskCompletionSource.trySet(result: ())
             }
         }
         return taskCompletionSource.task

--- a/Sources/BoltsSwift/Task.swift
+++ b/Sources/BoltsSwift/Task.swift
@@ -110,7 +110,7 @@ public final class Task<TResult> {
     public convenience init(_ executor: Executor = .Default, closure: (Void throws -> TResult)) {
         self.init(state: .Pending())
         executor.execute {
-            self.trySetState(TaskState.fromClosure(closure))
+            self.trySet(state: TaskState.fromClosure(closure))
         }
     }
 
@@ -234,7 +234,7 @@ public final class Task<TResult> {
 
     // MARK: State Change
 
-    func trySetState(state: TaskState<TResult>) -> Bool {
+    func trySet(state state: TaskState<TResult>) -> Bool {
         var stateChanged = false
 
         var continuations: [Continuation]?

--- a/Sources/BoltsSwift/TaskCompletionSource.swift
+++ b/Sources/BoltsSwift/TaskCompletionSource.swift
@@ -46,8 +46,8 @@ public class TaskCompletionSource<TResult> {
 
      - parameter result: The task result.
      */
-    public func setResult(result: TResult) {
-        guard task.trySetState(.Success(result)) else {
+    public func set(result result: TResult) {
+        guard task.trySet(state: .Success(result)) else {
             preconditionFailure("Can not set the result on a completed task.")
         }
     }
@@ -59,8 +59,8 @@ public class TaskCompletionSource<TResult> {
 
      - parameter error: The task error.
      */
-    public func setError(error: ErrorType) {
-        guard task.trySetState(.Error(error)) else {
+    public func set(error error: ErrorType) {
+        guard task.trySet(state: .Error(error)) else {
             preconditionFailure("Can not set error on a completed task.")
         }
     }
@@ -71,7 +71,7 @@ public class TaskCompletionSource<TResult> {
      Throws an exception if the task is already completed.
      */
     public func cancel() {
-        guard task.trySetState(.Cancelled) else {
+        guard task.trySet(state: .Cancelled) else {
             preconditionFailure("Can not cancel a completed task.")
         }
     }
@@ -82,8 +82,8 @@ public class TaskCompletionSource<TResult> {
      - parameter result: The task result.
      - returns: `true` if the result was set, `false` otherwise.
      */
-    public func trySetResult(result: TResult) -> Bool {
-        return task.trySetState(.Success(result))
+    public func trySet(result result: TResult) -> Bool {
+        return task.trySet(state: .Success(result))
     }
 
     /**
@@ -92,8 +92,8 @@ public class TaskCompletionSource<TResult> {
      - parameter error: The task error.
      - returns: `true` if the error was set, `false` otherwise.
      */
-    public func trySetError(error: ErrorType) -> Bool {
-        return task.trySetState(.Error(error))
+    public func trySet(error error: ErrorType) -> Bool {
+        return task.trySet(state: .Error(error))
     }
 
     /**
@@ -102,7 +102,7 @@ public class TaskCompletionSource<TResult> {
      - returns: `true` if the task was completed, `false` otherwise.
      */
     public func tryCancel() -> Bool {
-        return task.trySetState(.Cancelled)
+        return task.trySet(state: .Cancelled)
     }
 
     //--------------------------------------
@@ -110,7 +110,7 @@ public class TaskCompletionSource<TResult> {
     //--------------------------------------
 
     func setState(state: TaskState<TResult>) {
-        guard task.trySetState(state) else {
+        guard task.trySet(state: state) else {
             preconditionFailure("Can not complete a completed task.")
         }
     }

--- a/Tests/TaskCompletionSourceTests.swift
+++ b/Tests/TaskCompletionSourceTests.swift
@@ -13,8 +13,8 @@ import BoltsSwift
 class TaskCompletionSourceTests: XCTestCase {
 
     func testInit() {
-        let sut = TaskCompletionSource<String>()
-        let task = sut.task
+        let tcs = TaskCompletionSource<String>()
+        let task = tcs.task
 
         XCTAssertFalse(task.completed)
         XCTAssertFalse(task.faulted)
@@ -24,10 +24,10 @@ class TaskCompletionSourceTests: XCTestCase {
     }
 
     func testSetResult() {
-        let sut = TaskCompletionSource<String>()
-        let task = sut.task
+        let tcs = TaskCompletionSource<String>()
+        let task = tcs.task
 
-        sut.setResult(currentTestName)
+        tcs.set(result: currentTestName)
 
         XCTAssertTrue(task.completed)
         XCTAssertNotNil(task.result)
@@ -36,10 +36,10 @@ class TaskCompletionSourceTests: XCTestCase {
 
     func testSetError() {
         let error = NSError(domain: "com.bolts", code: 1, userInfo: nil)
-        let sut = TaskCompletionSource<String>()
-        let task = sut.task
+        let tcs = TaskCompletionSource<String>()
+        let task = tcs.task
 
-        sut.setError(error)
+        tcs.set(error: error)
 
         XCTAssertTrue(task.completed)
         XCTAssertTrue(task.faulted)
@@ -48,10 +48,10 @@ class TaskCompletionSourceTests: XCTestCase {
     }
 
     func testCancel() {
-        let sut = TaskCompletionSource<String>()
-        let task = sut.task
+        let tcs = TaskCompletionSource<String>()
+        let task = tcs.task
 
-        sut.cancel()
+        tcs.cancel()
 
         XCTAssertTrue(task.completed)
         XCTAssertTrue(task.cancelled)
@@ -61,7 +61,7 @@ class TaskCompletionSourceTests: XCTestCase {
         let sut = TaskCompletionSource<String>()
         let task = sut.task
 
-        let success = sut.trySetResult(currentTestName)
+        let success = sut.trySet(result: currentTestName)
 
         XCTAssertTrue(success)
         XCTAssertTrue(task.completed)
@@ -74,7 +74,7 @@ class TaskCompletionSourceTests: XCTestCase {
         let sut = TaskCompletionSource<String>()
         let task = sut.task
 
-        let success = sut.trySetError(error)
+        let success = sut.trySet(error: error)
 
         XCTAssertTrue(success)
         XCTAssertTrue(task.completed)
@@ -96,9 +96,9 @@ class TaskCompletionSourceTests: XCTestCase {
 
     func testTrySetResultReturningFalse() {
         let sut = TaskCompletionSource<String>()
-        sut.setResult(currentTestName)
+        sut.set(result: currentTestName)
 
-        let success = sut.trySetResult(currentTestName)
+        let success = sut.trySet(result: currentTestName)
 
         XCTAssertFalse(success)
     }
@@ -106,16 +106,16 @@ class TaskCompletionSourceTests: XCTestCase {
     func testTrySetErrorReturningFalse() {
         let error = NSError(domain: "com.bolts", code: 1, userInfo: nil)
         let sut = TaskCompletionSource<String>()
-        sut.setResult(currentTestName)
+        sut.set(result: currentTestName)
 
-        let success = sut.trySetError(error)
+        let success = sut.trySet(error: error)
 
         XCTAssertFalse(success)
     }
 
     func testTryCancelReturningFalse() {
         let sut = TaskCompletionSource<String>()
-        sut.setResult(currentTestName)
+        sut.set(result: currentTestName)
         let success = sut.tryCancel()
         XCTAssertFalse(success)
     }


### PR DESCRIPTION
This is public API breaking, but the changes are very easy.
Since we are going to bump a minor version in the next release - this can go into `1.2.0`.

Also, please note - explicit labels are added for future compatibility with Swift 3.0, where every label becomes required.
