### PR TITLE
Adding a new executor which takes an escaping closure

### DIFF
--- a/Sources/BoltsSwift/Executor.swift
+++ b/Sources/BoltsSwift/Executor.swift
@@ -44,6 +44,11 @@ public enum Executor {
      Passes closures to an executing closure.
      */
     case closure((() -> Void) -> Void)
+    
+    /**
+     Passes escaping closures to an executing closure.
+     */
+    case escapingClosure((@escaping () -> Void) -> Void)
 
     /**
      Executes the given closure using the corresponding strategy.
@@ -88,6 +93,8 @@ public enum Executor {
             operationQueue.addOperation(closure)
         case .closure(let executingClosure):
             executingClosure(closure)
+        case .escapingClosure(let executingEscapingClosure):
+            executingEscapingClosure(closure)
         }
     }
 }
@@ -108,6 +115,8 @@ extension Executor : CustomStringConvertible, CustomDebugStringConvertible {
             return "Executor with NSOperationQueue"
         case .closure:
             return "Executor with custom closure"
+        case .escapingClosure:
+            return "Executor with custom escaping closure"
         }
     }
 
@@ -119,6 +128,8 @@ extension Executor : CustomStringConvertible, CustomDebugStringConvertible {
         case .operationQueue(let queue):
             return "\(description): \(queue)"
         case .closure(let closure):
+            return "\(description): \(closure)"
+        case .escapingClosure(let closure):
             return "\(description): \(closure)"
         default:
             return description

--- a/Tests/ExecutorTests.swift
+++ b/Tests/ExecutorTests.swift
@@ -93,6 +93,18 @@ class ExecutorTests: XCTestCase {
 
         waitForTestExpectations()
     }
+    
+    func testEscapingClosureExecute() {
+        let expectation = self.expectation(description: currentTestName)
+        
+        Executor.escapingClosure { closure in
+            closure()
+            }.execute { () -> Void in
+                expectation.fulfill()
+        }
+        
+        waitForTestExpectations()
+    }
 
     func testOperationQueueExecute() {
         let expectation = self.expectation(description: currentTestName)


### PR DESCRIPTION
Since migrating to Swift3, all closure are now non escaping by default. The closure passed to the Executor was calling the [perform function](https://developer.apple.com/reference/coredata/nsmanagedobjectcontext/1506578-perform) from NSManagedObjectContext from CoreData which required an escaping closure.

That's why I added a new case for the Executor. I didn't want to modify the existing one to make sure it didn't break anything.

Feel free to comment / discuss about this.