### PR TITLE
Remove flatMap because it is now deprecated in Swift 4.1

### DIFF
--- a/Sources/BoltsSwift/Task+WhenAll.swift
+++ b/Sources/BoltsSwift/Task+WhenAll.swift
@@ -44,7 +44,11 @@ extension Task {
                     if cancelledCount > 0 {
                         tcs.cancel()
                     } else if errorCount > 0 {
-                        tcs.set(error: AggregateError(errors: tasks.flatMap({ $0.error })))
+                        #if swift(>=4.1)
+                            tcs.set(error: AggregateError(errors: tasks.compactMap({ $0.error })))
+                        #else
+                            tcs.set(error: AggregateError(errors: tasks.flatMap({ $0.error })))
+                        #endif
                     } else {
                         tcs.set(result: ())
                     }


### PR DESCRIPTION
With the release of Xcode 9.3 / Swift 4.1, Sequence.flatMap is deprecated for the usage of removing nil elements in a list. It has been replaced with new Sequence.compactMap as per this doc link:
[https://github.com/apple/swift-evolution/blob/master/proposals/0187-introduce-filtermap.md](https://github.com/apple/swift-evolution/blob/master/proposals/0187-introduce-filtermap.md)

This commit removes the compiler warning.