### PR TITLE
Add swift_version to podspec

### DIFF
--- a/Bolts-Swift.podspec
+++ b/Bolts-Swift.podspec
@@ -9,6 +9,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/BoltsFramework/Bolts-Swift.git', :tag => s.version.to_s }
 
   s.requires_arc = true
+  
+  s.swift_version = '4.0'
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
Specifies the swift version that CP will set to the pod target regardless of the swift version the app target uses.