### PR TITLE
Re-lint everything using SwiftLint 0.35.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,3 +6,4 @@ opt_in_rules:
 disabled_rules:
   - cyclomatic_complexity
   - variable_name
+  - no_fallthrough_only

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "BoltsSwift",
-            targets: ["BoltsSwift"]),
+            targets: ["BoltsSwift"])
     ],
     targets: [
         .target(
@@ -20,7 +20,7 @@ let package = Package(
         .testTarget(
             name: "BoltsSwiftTests",
             dependencies: ["BoltsSwift"],
-            path: "Tests"),
+            path: "Tests")
     ],
     swiftLanguageVersions: [.v4,
                             .v4_2,

--- a/Sources/BoltsSwift/Executor.swift
+++ b/Sources/BoltsSwift/Executor.swift
@@ -99,7 +99,7 @@ public enum Executor {
     }
 }
 
-extension Executor : CustomStringConvertible, CustomDebugStringConvertible {
+extension Executor: CustomStringConvertible, CustomDebugStringConvertible {
     /// A textual representation of `self`.
     public var description: String {
         switch self {

--- a/Sources/BoltsSwift/Executor.swift
+++ b/Sources/BoltsSwift/Executor.swift
@@ -44,7 +44,7 @@ public enum Executor {
      Passes closures to an executing closure.
      */
     case closure((() -> Void) -> Void)
-    
+
     /**
      Passes escaping closures to an executing closure.
      */

--- a/Sources/BoltsSwift/Task+ContinueWith.swift
+++ b/Sources/BoltsSwift/Task+ContinueWith.swift
@@ -24,9 +24,9 @@ extension Task {
      - returns: The task resulting from the continuation
      */
     fileprivate func continueWithTask<S>(_ executor: Executor,
-                                  options: TaskContinuationOptions,
-                                  continuation: @escaping ((Task) throws -> Task<S>)
-        ) -> Task<S> {
+                                         options: TaskContinuationOptions,
+                                         continuation: @escaping ((Task) throws -> Task<S>)
+    ) -> Task<S> {
         let taskCompletionSource = TaskCompletionSource<S>()
         let wrapperContinuation = {
             switch self.state {
@@ -120,7 +120,7 @@ extension Task {
      */
     @discardableResult
     public func continueOnSuccessWith<S>(_ executor: Executor = .default,
-                                      continuation: @escaping ((TResult) throws -> S)) -> Task<S> {
+                                         continuation: @escaping ((TResult) throws -> S)) -> Task<S> {
         return continueOnSuccessWithTask(executor) { taskResult in
             let state = TaskState.fromClosure({
                 try continuation(taskResult)
@@ -139,7 +139,7 @@ extension Task {
      */
     @discardableResult
     public func continueOnSuccessWithTask<S>(_ executor: Executor = .default,
-                                          continuation: @escaping ((TResult) throws -> Task<S>)) -> Task<S> {
+                                             continuation: @escaping ((TResult) throws -> Task<S>)) -> Task<S> {
         return continueWithTask(executor, options: .RunOnSuccess) { task in
             return try continuation(task.result!)
         }

--- a/Sources/BoltsSwift/Task+WhenAll.swift
+++ b/Sources/BoltsSwift/Task+WhenAll.swift
@@ -45,9 +45,9 @@ extension Task {
                         tcs.cancel()
                     } else if errorCount > 0 {
                         #if swift(>=4.1)
-                            tcs.set(error: AggregateError(errors: tasks.compactMap({ $0.error })))
+                        tcs.set(error: AggregateError(errors: tasks.compactMap({ $0.error })))
                         #else
-                            tcs.set(error: AggregateError(errors: tasks.flatMap({ $0.error })))
+                        tcs.set(error: AggregateError(errors: tasks.flatMap({ $0.error })))
                         #endif
                     } else {
                         tcs.set(result: ())

--- a/Sources/BoltsSwift/Task+WhenAny.swift
+++ b/Sources/BoltsSwift/Task+WhenAny.swift
@@ -35,7 +35,7 @@ extension Task {
             if taskCompletionSource.task.completed {
                 break
             }
-            task.continueWith { task in
+            task.continueWith { _ in
                 taskCompletionSource.trySet(result: ())
             }
         }

--- a/Tests/ExecutorTests.swift
+++ b/Tests/ExecutorTests.swift
@@ -67,7 +67,7 @@ class ExecutorTests: XCTestCase {
 
     func testQueueExecute() {
         let expectation = self.expectation(description: name)
-                let semaphore = DispatchSemaphore(value: 0)
+        let semaphore = DispatchSemaphore(value: 0)
         var finished = false
 
         Executor.queue(.global(qos: .default)).execute {
@@ -87,22 +87,21 @@ class ExecutorTests: XCTestCase {
 
         Executor.closure { closure in
             closure()
-            }.execute { () -> Void in
-                expectation.fulfill()
+        }.execute { () -> Void in
+            expectation.fulfill()
         }
 
         waitForTestExpectations()
     }
-    
+
     func testEscapingClosureExecute() {
         let expectation = self.expectation(description: name)
-        
         Executor.escapingClosure { closure in
             closure()
-            }.execute { () -> Void in
-                expectation.fulfill()
+        }.execute { () -> Void in
+            expectation.fulfill()
         }
-        
+
         waitForTestExpectations()
     }
 

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -52,7 +52,7 @@ class TaskTests: XCTestCase {
     func testWithDelay() {
         let expectation = self.expectation(description: name)
         let task = Task<String>.withDelay(0.01)
-        task.continueWith { task in
+        task.continueWith { _ in
             expectation.fulfill()
         }
 
@@ -280,7 +280,7 @@ class TaskTests: XCTestCase {
             XCTAssertTrue(task === initialTask)
         }
 
-        continuationTask.continueWith { task in
+        continuationTask.continueWith { _ in
             expectation.fulfill()
         }
         waitForTestExpectations()
@@ -401,7 +401,7 @@ class TaskTests: XCTestCase {
 
         for i in 1...20 {
             let task = Task<Void>.withDelay(0.5)
-                .continueWith(continuation: { task -> Int in
+                .continueWith(continuation: { _ -> Int in
                     OSAtomicIncrement32(&count)
                     return i
                 })
@@ -431,7 +431,7 @@ class TaskTests: XCTestCase {
 
         for i in 1...20 {
             let task = Task<Void>.withDelay(0.5)
-                .continueWith(executor, continuation: { task -> Int in
+                .continueWith(executor, continuation: { _ -> Int in
                     OSAtomicIncrement32(&count)
                     return i
                 })
@@ -462,7 +462,7 @@ class TaskTests: XCTestCase {
 
         for i in 1...20 {
             let task = Task<Void>.withDelay(0.5)
-                .continueWithTask(executor, continuation: { task -> Task<Int> in
+                .continueWithTask(executor, continuation: { _ -> Task<Int> in
                     OSAtomicIncrement32(&count)
                     if i == 20 {
                         return Task.cancelledTask()
@@ -494,7 +494,7 @@ class TaskTests: XCTestCase {
 
         for i in 1...20 {
             let task = Task<Void>.withDelay(0.5)
-                .continueWith(continuation: { task in
+                .continueWith(continuation: { _ in
                     OSAtomicIncrement32(&count)
                     throw NSError(domain: "bolts", code: i, userInfo: nil)
                 })
@@ -530,13 +530,13 @@ class TaskTests: XCTestCase {
         var count: Int32 = 0
         let executor = Executor.queue(DispatchQueue.global(qos: .default))
 
-        tasks.append(Task<Void>.withDelay(0.2).continueWith { task in
+        tasks.append(Task<Void>.withDelay(0.2).continueWith { _ in
             // Use max value of Int32, so we can use the same code across both 32 and 64 bit archs.
             return Int(arc4random_uniform(UInt32(Int32.max)))
         })
         for i in 1...20 {
             let task = Task<Void>.withDelay(0.5)
-                .continueWith(executor, continuation: { task -> Int in
+                .continueWith(executor, continuation: { _ -> Int in
                     OSAtomicIncrement32(&count)
                     return i
                 })
@@ -568,7 +568,7 @@ class TaskTests: XCTestCase {
 
         for i in 1...20 {
             let task = Task<Void>.withDelay(Double(i) * 0.5)
-                .continueWithTask(executor, continuation: { task -> Task<Void> in
+                .continueWithTask(executor, continuation: { _ -> Task<Void> in
                     OSAtomicIncrement32(&count)
                     return Task(error: error)
                 })
@@ -599,7 +599,7 @@ class TaskTests: XCTestCase {
 
         for i in 1...20 {
             let task = Task<Void>.withDelay(Double(i) * 0.5)
-                .continueWithTask(executor, continuation: { task -> Task<Int> in
+                .continueWithTask(executor, continuation: { _ -> Task<Int> in
                     OSAtomicIncrement32(&count)
                     return Task.cancelledTask()
                 })

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -294,23 +294,23 @@ class TaskTests: XCTestCase {
             count += 1
             XCTAssertEqual(count, 1)
             return nil
-            }.continueWith { _ -> String? in
-                count += 1
-                XCTAssertEqual(count, 2)
-                return nil
-            }.continueWith { _ -> String? in
-                count += 1
-                XCTAssertEqual(count, 3)
-                return nil
-            }.continueWith { _ -> String? in
-                count += 1
-                XCTAssertEqual(count, 4)
-                return nil
-            }.continueWith { _ -> String? in
-                count += 1
-                XCTAssertEqual(count, 5)
-                expectation.fulfill()
-                return nil
+        }.continueWith { _ -> String? in
+            count += 1
+            XCTAssertEqual(count, 2)
+            return nil
+        }.continueWith { _ -> String? in
+            count += 1
+            XCTAssertEqual(count, 3)
+            return nil
+        }.continueWith { _ -> String? in
+            count += 1
+            XCTAssertEqual(count, 4)
+            return nil
+        }.continueWith { _ -> String? in
+            count += 1
+            XCTAssertEqual(count, 5)
+            expectation.fulfill()
+            return nil
         }
 
         waitForTestExpectations()
@@ -324,19 +324,19 @@ class TaskTests: XCTestCase {
         Task<Void>.cancelledTask().continueWith(executor) { _ in
             count += 1
             XCTAssertEqual(count, 1)
-            }.continueWith(executor) { _ in
-                count += 1
-                XCTAssertEqual(count, 2)
-            }.continueWith(executor) { _ in
-                count += 1
-                XCTAssertEqual(count, 3)
-            }.continueWith(executor) { _ in
-                count += 1
-                XCTAssertEqual(count, 4)
-            }.continueWith(executor) { _ in
-                count += 1
-                XCTAssertEqual(count, 5)
-                expectation.fulfill()
+        }.continueWith(executor) { _ in
+            count += 1
+            XCTAssertEqual(count, 2)
+        }.continueWith(executor) { _ in
+            count += 1
+            XCTAssertEqual(count, 3)
+        }.continueWith(executor) { _ in
+            count += 1
+            XCTAssertEqual(count, 4)
+        }.continueWith(executor) { _ in
+            count += 1
+            XCTAssertEqual(count, 5)
+            expectation.fulfill()
         }
 
         waitForTestExpectations()
@@ -638,19 +638,19 @@ class TaskTests: XCTestCase {
         Task<Void>.cancelledTask().continueWith { _ in
             count += 1
             XCTAssertEqual(count, 1)
-            }.continueWith { _ in
-                count += 1
-                XCTAssertEqual(count, 2)
-            }.continueWith { _ in
-                count += 1
-                XCTAssertEqual(count, 3)
-            }.continueWith { _ in
-                count += 1
-                XCTAssertEqual(count, 4)
-            }.continueWith { _ in
-                count += 1
-                XCTAssertEqual(count, 5)
-            }.waitUntilCompleted()
+        }.continueWith { _ in
+            count += 1
+            XCTAssertEqual(count, 2)
+        }.continueWith { _ in
+            count += 1
+            XCTAssertEqual(count, 3)
+        }.continueWith { _ in
+            count += 1
+            XCTAssertEqual(count, 4)
+        }.continueWith { _ in
+            count += 1
+            XCTAssertEqual(count, 5)
+        }.waitUntilCompleted()
         XCTAssertEqual(count, 5)
     }
 }

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -396,7 +396,7 @@ class TaskTests: XCTestCase {
     }
 
     func testWhenAllTasksSuccess() {
-        var tasks = Array<Task<Int>>()
+        var tasks = [Task<Int>]()
         var count: Int32 = 0
 
         for i in 1...20 {
@@ -425,7 +425,7 @@ class TaskTests: XCTestCase {
     }
 
     func testWhenAllTasksWithResultSuccess() {
-        var tasks = Array<Task<Int>>()
+        var tasks = [Task<Int>]()
         var count: Int32 = 0
         let executor = Executor.queue(DispatchQueue.global(qos: .default))
 
@@ -456,7 +456,7 @@ class TaskTests: XCTestCase {
     }
 
     func testWhenAllTasksWithCancel() {
-        var tasks = Array<Task<Int>>()
+        var tasks = [Task<Int>]()
         var count: Int32 = 0
         let executor = Executor.queue(DispatchQueue.global(qos: .default))
 
@@ -526,7 +526,7 @@ class TaskTests: XCTestCase {
     // MARK: When Any
 
     func testWhenAnyTasksSuccess() {
-        var tasks = Array<Task<Int>>()
+        var tasks = [Task<Int>]()
         var count: Int32 = 0
         let executor = Executor.queue(DispatchQueue.global(qos: .default))
 
@@ -560,7 +560,7 @@ class TaskTests: XCTestCase {
     }
 
     func testWhenAnyTasksWithErrors() {
-        var tasks = Array<Task<Void>>()
+        var tasks = [Task<Void>]()
         var count: Int32 = 0
 
         let executor = Executor.queue(DispatchQueue.global(qos: .default))
@@ -592,7 +592,7 @@ class TaskTests: XCTestCase {
     }
 
     func testWhenAnyTasksWithCancel() {
-        var tasks = Array<Task<Int>>()
+        var tasks = [Task<Int>]()
         var count: Int32 = 0
 
         let executor = Executor.queue(DispatchQueue.global(qos: .default))

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -508,7 +508,7 @@ class TaskTests: XCTestCase {
             XCTAssertTrue(task.faulted)
             XCTAssertFalse(task.cancelled)
             guard let error = task.error as? AggregateError else {
-                XCTFail()
+                XCTFail("Not an aggregate error returned.")
                 expectation.fulfill()
                 return
             }


### PR DESCRIPTION
Re-linting the whole codebase using the latest version of SwiftLint.
Fixes a few warnings and opts-out from the rule that is not applicable to our case.