### PR TITLE
Set MacOSX minimum deployment target to 10.10

### DIFF
--- a/BoltsSwift.xcodeproj/project.pbxproj
+++ b/BoltsSwift.xcodeproj/project.pbxproj
@@ -778,6 +778,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 812DB53B1D3597BF00552C9F /* Debug.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 			};
 			name = Debug;
 		};
@@ -785,6 +786,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 812DB53C1D3597BF00552C9F /* Release.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Properly sets the minimum deployment target to 10.10. If this is not set it will set the minimum version to the MacOS default. 13.1 in my case.

@nlutsenko